### PR TITLE
グループ名・メンバーの表示、グループ名編集実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,7 @@ gem 'font-awesome-sass'
 gem 'devise'
 
 gem 'pry-rails'
+
+gem "carrierwave"
+
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
@@ -105,6 +112,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
+    image_processing (1.11.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     listen (3.1.5)
@@ -120,6 +130,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -175,6 +186,8 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
@@ -245,11 +258,13 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  carrierwave
   devise
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4)
   pry-rails
   puma (~> 3.11)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -98,7 +98,7 @@ $c3black: #333333;
       color: #999999;
       font-size: 12px;
     }
-    &__text__edit {
+    &__a {
       width: 72px;
       text-decoration: none;
       padding: 11px 20px;
@@ -124,7 +124,6 @@ $c3black: #333333;
     &__title__inner {
       color: #434a54;
       font-size: 14px;
-      padding: 0;
       margin-bottom: 46px;
     }
     &__name {
@@ -139,11 +138,9 @@ $c3black: #333333;
     &__message-form {
       height: 90px;
       background-color: #d2d2d2;
-    }
-    &__message__box {
-      display: $flex;
       padding: 20px 40px;
     }
+
     &__message__contents {
       display: $flex;
       width: 100%;
@@ -154,14 +151,14 @@ $c3black: #333333;
       height: 50px;
       padding-left: 15px;
       color: #999999;
-      border: none;
+      border: none; 
     }
     &__message-icon {
       font-size: 25px;
       line-height: 50px;
       color: black;
       position: absolute;
-      right: 10px;
+      right: 130px;
       cursor: pointer;
     }
     &__message-btn {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,7 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
 
-  def index 
+  def index
   end
   
   def new
@@ -11,27 +12,29 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     if @group.save
-      redirect_to 'root_path', notice: 'グループを作成しました'
+      redirect_to root_path, notice: 'グループを作成しました'
     else
       render :new
     end
   end
 
   def edit
-    @group = Group.find(params[:id])
   end
 
   def update
-    @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to groups_path, notice: 'グループを更新しました'
     else
       render :edit
     end
   end
-
+''
   private
   def group_params
     params.require(:group).permit(:name, user_ids: [] )
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,30 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
   end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
+
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,19 @@
 class Group < ApplicationRecord 
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
+
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      if last_message.content?
+        last_message.content
+      else
+        '画像が投稿されています'
+      end
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,7 @@
+class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+  validates :content, presence: true, unless: :image
+
+  mount_uploader :image, ImageUploader
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-
+  has_many :messages
   has_many :group_users
   has_many :groups, through: :group_users
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,47 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+    process resize_to_fit: [800, 800]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,28 +1,25 @@
 .Chat-main
   .Chat-main__info
     .Chat-main__left
-      %p.Chat-main__text test
-      %p.Chat-main__text__inner Member :masa
+      %p.Chat-main__text 
+      = @group.name
+      .Chat-main__text__inner
+        Member:
+        - @group.users.each do |user|
+          = user.name
     .Chat-main__right
-      %a.Chat-main__text__edit{ href: '#' }Edit
+      .Chat-main__text__edit 
+        = link_to edit_group_path(@group.id), class: 'Chat-main__a' do
+          Edit
 
   .Chat-main__message-list
-    .Chat-main__main
-      %p.Chat-main__name masa
-      %p.Chat-main__time 2019/11/20(Wed) 17:43:00
-    .Chat-main__title
-      %span.Chat-main__title__inner おはよう！
-    .Chat-main__main
-      %p.Chat-main__name masa
-      %p.Chat-main__time 2019/11/20(Wed) 17:43:34
-    .Chat-main__title
-      %span.Chat-main__title__inner 今日は夜から雨
+    = render @messages
 
   .Chat-main__message-form
-    .Chat-main__message__box
+    = form_with model: [@group, @message], html: {class: "Form"}, local: true do |f|
       .Chat-main__message__contents
-        %input.Chat-main__message-left{:type => "text",:placeholder => "type a message"}
-        %label{class: "form-image"}
+        = f.text_field :content, class: 'Chat-main__message-left', placeholder: 'type a message'
+        = f.label :image, class: "form-image" do
           = icon('fas' , 'image', class: 'Chat-main__message-icon')
-          %input{type: "file", class: 'Chat-main__file-delete'}
-      %input.Chat-main__message-btn{type: "submit", value: "SEND"}
+        = f.file_field :image, class: 'Chat-main__file-delete'
+        = f.submit 'Send', class: 'Chat-main__message-btn'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,10 @@
+.Chat-main__main
+  .Chat-main__name
+    = message.user.name
+  .Chat-main__time
+    = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+.Chat-main__title
+  - if message.content.present?
+    %p.Chat-main__title__inner
+      = message.content
+  = image_tag message.image.url, class: 'Message__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -12,8 +12,8 @@
   .Side-bar__list
     - current_user.groups.each do |group|
       .Side-bar__inner
-        = link_to '#' do
+        = link_to group_messages_path(group) do
           .Side-bar__text
             = group.name
           .Side-bar__text__inner
-            メッセージはありません
+            = group.show_last_message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update]
+  resources :groups, only: [:index, :new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/db/migrate/20200625075804_create_messages.rb
+++ b/db/migrate/20200625075804_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :user, foreign_key: true
+      t.references :group,  foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_064548) do
+ActiveRecord::Schema.define(version: 2020_06_25_075804) do
 
   create_table "group_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "group_id"
@@ -28,6 +28,17 @@ ActiveRecord::Schema.define(version: 2020_06_24_064548) do
     t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "content"
+    t.string "image"
+    t.bigint "user_id"
+    t.bigint "group_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_messages_on_group_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -41,4 +52,6 @@ ActiveRecord::Schema.define(version: 2020_06_24_064548) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
[What]
 ヘッダー部分にグループ名とメンバーを表示させました。グループ名の編集できるようにしました。

[Why]
どこのグループにいて、誰がいるのかユーザー側は、分かるような表示が必要だと思ったからです。
複数グループに所属していると管理しにくいかったりするので作らせていただきました。